### PR TITLE
fix: Marked `CA5394` as NoWarn

### DIFF
--- a/src/NetEvolve.Defaults/build/SupportGeneral.props
+++ b/src/NetEvolve.Defaults/build/SupportGeneral.props
@@ -36,7 +36,7 @@
 
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 
-    <NoWarn>$(NoWarn);CA1810;CA1031;</NoWarn>
+    <NoWarn>$(NoWarn);CA1810;CA1031;CA5394;</NoWarn>
     <NoWarn Condition=" '$(IsTestableProject)' == 'true' ">$(NoWarn);CS8604;CA2007;S4144;1591;CA1707;IDE1006;VSTHRD200;CA1822;CA1515;S3011;S1192</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5394