### PR TITLE
fix: Disable `GeneratePackageOnBuild` if build inside of Visual Studio

### DIFF
--- a/src/NetEvolve.Defaults/build/SupportPackageInformation.props
+++ b/src/NetEvolve.Defaults/build/SupportPackageInformation.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup Label="Package Information" Condition=" '$(IsTestableProject)' != 'true' ">
+  <PropertyGroup Label="Package Information" Condition=" '$(IsTestableProject)' != 'true' and '$(BuildingInsideVisualStudio)' != 'true' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to refine package generation conditions for improved development workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->