### PR TITLE
test(analyzer): add unit test coverage for NetEvolve.Defaults.Analyzer

### DIFF
--- a/Defaults.sln
+++ b/Defaults.sln
@@ -32,6 +32,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetEvolve.Defaults.Tests.In
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetEvolve.Defaults.Analyzer", "src\NetEvolve.Defaults.Analyzer\NetEvolve.Defaults.Analyzer.csproj", "{04A3A934-D585-42BD-B551-501F3ED99086}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetEvolve.Defaults.Analyzer.Tests.Unit", "tests\NetEvolve.Defaults.Analyzer.Tests.Unit\NetEvolve.Defaults.Analyzer.Tests.Unit.csproj", "{DB035780-3F09-4929-AAA0-8121EA80BB8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{04A3A934-D585-42BD-B551-501F3ED99086}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{04A3A934-D585-42BD-B551-501F3ED99086}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{04A3A934-D585-42BD-B551-501F3ED99086}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB035780-3F09-4929-AAA0-8121EA80BB8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB035780-3F09-4929-AAA0-8121EA80BB8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB035780-3F09-4929-AAA0-8121EA80BB8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB035780-3F09-4929-AAA0-8121EA80BB8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -58,5 +64,6 @@ Global
 		{C9525AC4-A52E-4D52-A9A4-389D9FF6A1CE} = {4AD0D117-4F9D-4288-B0F9-D8C1C120B5E4}
 		{7A7B8583-0494-496B-A63F-C0134194D633} = {DB9397A5-7522-4CF5-B402-E4FFC93E600B}
 		{04A3A934-D585-42BD-B551-501F3ED99086} = {4AD0D117-4F9D-4288-B0F9-D8C1C120B5E4}
+		{DB035780-3F09-4929-AAA0-8121EA80BB8E} = {DB9397A5-7522-4CF5-B402-E4FFC93E600B}
 	EndGlobalSection
 EndGlobal

--- a/src/NetEvolve.Defaults.Analyzer/Diagnostics/OldProjectSupportDiagnosticAnalyzer.cs
+++ b/src/NetEvolve.Defaults.Analyzer/Diagnostics/OldProjectSupportDiagnosticAnalyzer.cs
@@ -36,22 +36,14 @@ internal sealed class OldProjectSupportDiagnosticAnalyzer : DiagnosticAnalyzer
         {
             var options = ctx.Options.AnalyzerConfigOptionsProvider.GlobalOptions;
 
-            AnalyzeIsKeySet(ctx, options, _ruleOLD0001, "build_property.direngineering");
-            AnalyzeIsKeySet(ctx, options, _ruleOLD0001, "build_property.direngineeringsettings");
+            if (
+                IsConfigured(options, "build_property.direngineering")
+                || IsConfigured(options, "build_property.direngineeringsettings")
+            )
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(_ruleOLD0001, null));
+            }
         });
-    }
-
-    private static void AnalyzeIsKeySet(
-        CompilationAnalysisContext context,
-        AnalyzerConfigOptions options,
-        DiagnosticDescriptor descriptor,
-        string key
-    )
-    {
-        if (IsConfigured(options, key))
-        {
-            context.ReportDiagnostic(Diagnostic.Create(descriptor, null));
-        }
     }
 
     private static bool IsConfigured(AnalyzerConfigOptions options, string key)

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/AnalyzerTestHelper.cs
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/AnalyzerTestHelper.cs
@@ -1,0 +1,68 @@
+﻿namespace NetEvolve.Defaults.Analyzer.Tests.Unit;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+internal static class AnalyzerTestHelper
+{
+    private const string DefaultSource = "namespace Sample; internal sealed class Sample { }";
+
+    internal static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        DiagnosticAnalyzer analyzer,
+        IReadOnlyDictionary<string, string?>? globalOptions = null,
+        string source = DefaultSource
+    )
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(
+            "AnalyzerTestAssembly",
+            [syntaxTree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        var optionsProvider = new TestAnalyzerConfigOptionsProvider(
+            new TestAnalyzerConfigOptions(globalOptions ?? new Dictionary<string, string?>())
+        );
+        var analyzerOptions = new AnalyzerOptions([], optionsProvider);
+
+        var withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
+
+        var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync();
+
+        return diagnostics;
+    }
+
+    private sealed class TestAnalyzerConfigOptionsProvider(AnalyzerConfigOptions globalOptions)
+        : AnalyzerConfigOptionsProvider
+    {
+        public override AnalyzerConfigOptions GlobalOptions { get; } = globalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => GlobalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => GlobalOptions;
+    }
+
+    private sealed class TestAnalyzerConfigOptions(IReadOnlyDictionary<string, string?> values) : AnalyzerConfigOptions
+    {
+        public override bool TryGetValue(string key, out string value)
+        {
+            if (values.TryGetValue(key, out var found) && found is not null)
+            {
+                value = found;
+
+                return true;
+            }
+
+            value = string.Empty;
+
+            return false;
+        }
+    }
+}

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/HelperTests.cs
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/HelperTests.cs
@@ -1,0 +1,101 @@
+namespace NetEvolve.Defaults.Analyzer.Tests.Unit;
+
+using System;
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+
+internal class HelperTests
+{
+    [Test]
+    public async Task CreateUsageDescriptor_NullId_ThrowsArgumentNullException() =>
+        await Assert.That(() => Helper.CreateUsageDescriptor(null!)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task CreateUsageDescriptor_EmptyId_ThrowsArgumentNullException() =>
+        await Assert.That(() => Helper.CreateUsageDescriptor(string.Empty)).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task CreateUsageDescriptor_WhitespaceId_ThrowsArgumentNullException() =>
+        await Assert.That(() => Helper.CreateUsageDescriptor("   ")).Throws<ArgumentNullException>();
+
+    [Test]
+    public async Task CreateUsageDescriptor_ValidId_ReturnsExpectedDescriptor()
+    {
+        var descriptor = Helper.CreateUsageDescriptor("NED0001");
+
+        await Assert.That(descriptor.Id).IsEqualTo("NED0001");
+        await Assert.That(descriptor.Category).IsEqualTo(RuleCategory.Usage.ToString());
+        await Assert.That(descriptor.DefaultSeverity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(descriptor.IsEnabledByDefault).IsTrue();
+        await Assert.That(descriptor.Title.ToString(CultureInfo.InvariantCulture)).IsNotEmpty();
+        await Assert.That(descriptor.MessageFormat.ToString(CultureInfo.InvariantCulture)).IsNotEmpty();
+        await Assert.That(descriptor.Description.ToString(CultureInfo.InvariantCulture)).IsNotEmpty();
+    }
+
+    [Test]
+    public async Task CreateUsageDescriptor_CustomSeverity_PropagatesSeverity()
+    {
+        var descriptor = Helper.CreateUsageDescriptor("NED0009", DiagnosticSeverity.Info);
+
+        await Assert.That(descriptor.DefaultSeverity).IsEqualTo(DiagnosticSeverity.Info);
+    }
+
+    [Test]
+    public async Task CreateUsageDescriptor_IsEnabledByDefaultFalse_PropagatesValue()
+    {
+        var descriptor = Helper.CreateUsageDescriptor("NED0001", DiagnosticSeverity.Warning, isEnabledByDefault: false);
+
+        await Assert.That(descriptor.IsEnabledByDefault).IsFalse();
+    }
+
+    [Test]
+    public async Task CreateUsageDescriptor_CustomTags_PropagatesAllTags()
+    {
+        var descriptor = Helper.CreateUsageDescriptor(
+            "OLD0001",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            "compilationEnd",
+            "custom"
+        );
+
+        await Assert.That(descriptor.CustomTags).IsEquivalentTo(["compilationEnd", "custom"]);
+    }
+
+    [Test]
+    public async Task CreateUsageDescriptor_HelpLinkUri_IsLowercasedAndFormatted()
+    {
+        var descriptor = Helper.CreateUsageDescriptor("NED0001");
+
+        await Assert
+            .That(descriptor.HelpLinkUri)
+            .IsEqualTo("https://github.com/dailydevops/defaults/blob/main/docs/usage/ned0001.md");
+    }
+
+    [Test]
+    public async Task CreateUsageDescriptor_HelpLinkUri_MixedCaseId_IsFullyLowercased()
+    {
+        var descriptor = Helper.CreateUsageDescriptor("NeD0002");
+
+        await Assert
+            .That(descriptor.HelpLinkUri)
+            .IsEqualTo("https://github.com/dailydevops/defaults/blob/main/docs/usage/ned0002.md");
+    }
+
+    [Test]
+    [Arguments(RuleCategory.Design, (byte)0)]
+    [Arguments(RuleCategory.Naming, (byte)1)]
+    [Arguments(RuleCategory.Style, (byte)2)]
+    [Arguments(RuleCategory.Usage, (byte)3)]
+    [Arguments(RuleCategory.Performance, (byte)4)]
+    [Arguments(RuleCategory.Security, (byte)5)]
+    public async Task RuleCategory_UnderlyingValues_MatchExpected(RuleCategory category, byte expected) =>
+        await Assert.That((byte)category).IsEqualTo(expected);
+
+    [Test]
+    public async Task RuleCategory_HasExactlySixMembers()
+    {
+        await Assert.That(Enum.GetNames<RuleCategory>()).Count().IsEqualTo(6);
+        await Assert.That(Enum.GetValues<RuleCategory>()).Count().IsEqualTo(6);
+    }
+}

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/IsPackableProjectDiagnosticAnalyzerTests.cs
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/IsPackableProjectDiagnosticAnalyzerTests.cs
@@ -1,0 +1,282 @@
+namespace NetEvolve.Defaults.Analyzer.Tests.Unit;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using NetEvolve.Defaults.Analyzer.Diagnostics;
+using TUnit.Assertions.Enums;
+
+public class IsPackableProjectDiagnosticAnalyzerTests
+{
+    private static Dictionary<string, string?> CreateValidOptions() =>
+        new()
+        {
+            ["build_property.ispackable"] = "true",
+            ["build_property.packageid"] = "Some.Package.Id",
+            ["build_property.title"] = "Some Title",
+            ["build_property.description"] = "Some Description",
+            ["build_property.packagetags"] = "tag1;tag2",
+            ["build_property.packageprojecturl"] = "https://example.com/project",
+            ["build_property.repositoryurl"] = "https://example.com/repo",
+            ["build_property.authors"] = "Some Author",
+            ["build_property.company"] = "Some Company",
+            ["build_property.copyrightyearstart"] = "2024",
+        };
+
+    [Test]
+    public async Task Analyze_IsPackableNotSet_NoDiagnostics()
+    {
+        var options = new Dictionary<string, string?>();
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_IsPackableFalse_NoDiagnostics()
+    {
+        var options = new Dictionary<string, string?> { ["build_property.ispackable"] = "false" };
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_IsPackableUnparseable_TreatedAsNotPackable_NoDiagnostics()
+    {
+        var options = new Dictionary<string, string?> { ["build_property.ispackable"] = "notabool" };
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_IsPackableTrue_AllKeysValid_NoDiagnostics()
+    {
+        var options = CreateValidOptions();
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    [Arguments("build_property.packageid", "NED0001")]
+    [Arguments("build_property.title", "NED0002")]
+    [Arguments("build_property.description", "NED0003")]
+    [Arguments("build_property.packagetags", "NED0004")]
+    [Arguments("build_property.packageprojecturl", "NED0005")]
+    [Arguments("build_property.repositoryurl", "NED0006")]
+    [Arguments("build_property.authors", "NED0007")]
+    [Arguments("build_property.company", "NED0008")]
+    public async Task Analyze_SingleKeyMissing_FiresExpectedDiagnostic(string key, string expectedId)
+    {
+        var options = CreateValidOptions();
+        _ = options.Remove(key);
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo(expectedId);
+    }
+
+    [Test]
+    [Arguments("build_property.packageid", "NED0001")]
+    [Arguments("build_property.title", "NED0002")]
+    [Arguments("build_property.description", "NED0003")]
+    [Arguments("build_property.packagetags", "NED0004")]
+    [Arguments("build_property.packageprojecturl", "NED0005")]
+    [Arguments("build_property.repositoryurl", "NED0006")]
+    [Arguments("build_property.authors", "NED0007")]
+    [Arguments("build_property.company", "NED0008")]
+    public async Task Analyze_SingleKeyWhitespaceOnly_FiresExpectedDiagnostic(string key, string expectedId)
+    {
+        var options = CreateValidOptions();
+        options[key] = "   ";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo(expectedId);
+    }
+
+    [Test]
+    public async Task Analyze_CopyrightYearStart_Missing_FiresNed0009()
+    {
+        var options = CreateValidOptions();
+        _ = options.Remove("build_property.copyrightyearstart");
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("NED0009");
+    }
+
+    [Test]
+    public async Task Analyze_CopyrightYearStart_NonNumeric_FiresNed0009()
+    {
+        var options = CreateValidOptions();
+        options["build_property.copyrightyearstart"] = "abc";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("NED0009");
+    }
+
+    [Test]
+    public async Task Analyze_CopyrightYearStart_BoundaryLow_1900_DoesNotFire()
+    {
+        var options = CreateValidOptions();
+        options["build_property.copyrightyearstart"] = "1900";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_CopyrightYearStart_BoundaryHigh_9999_DoesNotFire()
+    {
+        var options = CreateValidOptions();
+        options["build_property.copyrightyearstart"] = "9999";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_CopyrightYearStart_JustBelowLow_1899_Fires()
+    {
+        var options = CreateValidOptions();
+        options["build_property.copyrightyearstart"] = "1899";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("NED0009");
+    }
+
+    [Test]
+    public async Task Analyze_CopyrightYearStart_JustAboveHigh_10000_Fires()
+    {
+        var options = CreateValidOptions();
+        options["build_property.copyrightyearstart"] = "10000";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("NED0009");
+    }
+
+    [Test]
+    public async Task Analyze_CopyrightYearStart_SurroundingWhitespace_TrimmedByTryParse_DoesNotFire()
+    {
+        var options = CreateValidOptions();
+        options["build_property.copyrightyearstart"] = "  2024  ";
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_CopyrightYearStart_Missing_DefaultSeverityIsInfo()
+    {
+        var options = CreateValidOptions();
+        _ = options.Remove("build_property.copyrightyearstart");
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Severity).IsEqualTo(DiagnosticSeverity.Info);
+    }
+
+    [Test]
+    public async Task Analyze_MultipleKeysMissing_FiresOnlyCorrespondingDiagnostics()
+    {
+        var options = CreateValidOptions();
+        _ = options.Remove("build_property.packageid");
+        _ = options.Remove("build_property.title");
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new IsPackableProjectDiagnosticAnalyzer(),
+            options
+        );
+
+        var ids = diagnostics.Select(d => d.Id).OrderBy(id => id, StringComparer.Ordinal).ToArray();
+
+        await Assert.That(ids).IsEquivalentTo(["NED0001", "NED0002"]);
+    }
+
+    [Test]
+    public async Task SupportedDiagnostics_ReturnsExpectedDescriptorsInOrder()
+    {
+        var analyzer = new IsPackableProjectDiagnosticAnalyzer();
+
+        var ids = analyzer.SupportedDiagnostics.Select(d => d.Id).ToArray();
+
+        await Assert
+            .That(ids)
+            .IsEquivalentTo(
+                ["NED0001", "NED0002", "NED0003", "NED0004", "NED0005", "NED0006", "NED0007", "NED0008", "NED0009"],
+                CollectionOrdering.Matching
+            );
+    }
+
+    [Test]
+    public async Task Initialize_ContextNull_ThrowsArgumentNullException()
+    {
+        var analyzer = new IsPackableProjectDiagnosticAnalyzer();
+
+        await Assert.That(() => analyzer.Initialize(null!)).Throws<ArgumentNullException>();
+    }
+}

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/NetEvolve.Defaults.Analyzer.Tests.Unit.csproj
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/NetEvolve.Defaults.Analyzer.Tests.Unit.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(NetEvolve_TestTargetFrameworks)</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);VSTHRD200;</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="NetEvolve.Extensions.TUnit" />
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="NetEvolve.Extensions.TUnit.UnitTestAttribute" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NetEvolve.Defaults.Analyzer\NetEvolve.Defaults.Analyzer.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/OldProjectSupportDiagnosticAnalyzerTests.cs
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/OldProjectSupportDiagnosticAnalyzerTests.cs
@@ -1,0 +1,113 @@
+namespace NetEvolve.Defaults.Analyzer.Tests.Unit;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NetEvolve.Defaults.Analyzer.Diagnostics;
+
+public class OldProjectSupportDiagnosticAnalyzerTests
+{
+    [Test]
+    public async Task Analyze_NeitherKeySet_NoDiagnostics()
+    {
+        var globalOptions = new Dictionary<string, string?>();
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new OldProjectSupportDiagnosticAnalyzer(),
+            globalOptions
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_OnlyDirEngineeringSet_ReportsSingleDiagnostic()
+    {
+        var globalOptions = new Dictionary<string, string?> { ["build_property.direngineering"] = "true" };
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new OldProjectSupportDiagnosticAnalyzer(),
+            globalOptions
+        );
+
+        await Assert.That(diagnostics).HasCount().EqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("OLD0001");
+    }
+
+    [Test]
+    public async Task Analyze_OnlyDirEngineeringSettingsSet_ReportsSingleDiagnostic()
+    {
+        var globalOptions = new Dictionary<string, string?> { ["build_property.direngineeringsettings"] = "true" };
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new OldProjectSupportDiagnosticAnalyzer(),
+            globalOptions
+        );
+
+        await Assert.That(diagnostics).HasCount().EqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("OLD0001");
+    }
+
+    [Test]
+    public async Task Analyze_DirEngineeringWhitespaceOnly_NoDiagnostics()
+    {
+        var globalOptions = new Dictionary<string, string?> { ["build_property.direngineering"] = "   " };
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new OldProjectSupportDiagnosticAnalyzer(),
+            globalOptions
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_DirEngineeringSettingsWhitespaceOnly_NoDiagnostics()
+    {
+        var globalOptions = new Dictionary<string, string?> { ["build_property.direngineeringsettings"] = "   " };
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new OldProjectSupportDiagnosticAnalyzer(),
+            globalOptions
+        );
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task BothKeysConfigured_ReportsSingleDiagnostic()
+    {
+        var globalOptions = new Dictionary<string, string?>
+        {
+            ["build_property.direngineering"] = "true",
+            ["build_property.direngineeringsettings"] = "true",
+        };
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
+            new OldProjectSupportDiagnosticAnalyzer(),
+            globalOptions
+        );
+
+        await Assert.That(diagnostics).HasCount().EqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("OLD0001");
+    }
+
+    [Test]
+    public async Task SupportedDiagnostics_ReturnsSingleOLD0001Descriptor()
+    {
+        var analyzer = new OldProjectSupportDiagnosticAnalyzer();
+
+        var supportedDiagnostics = analyzer.SupportedDiagnostics;
+
+        await Assert.That(supportedDiagnostics).HasCount().EqualTo(1);
+        await Assert.That(supportedDiagnostics[0].Id).IsEqualTo("OLD0001");
+    }
+
+    [Test]
+    public async Task Initialize_ContextNull_ThrowsArgumentNullException()
+    {
+        var analyzer = new OldProjectSupportDiagnosticAnalyzer();
+
+        await Assert.That(() => analyzer.Initialize(null!)).Throws<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary
- Add a new `NetEvolve.Defaults.Analyzer.Tests.Unit` TUnit project covering `IsPackableProjectDiagnosticAnalyzer`, `OldProjectSupportDiagnosticAnalyzer`, and `Helper`/`RuleCategory`, including edge cases (missing/whitespace values, boundary years, invalid input) beyond the happy path.
- Fix a bug found by the new tests: `OldProjectSupportDiagnosticAnalyzer` reported `OLD0001` twice when both `direngineering` and `direngineeringsettings` were configured. It now reports once.

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` in `tests/NetEvolve.Defaults.Analyzer.Tests.Unit` — 55/55 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cR8rWVwvVY2bfM4QyKvtw