### PR TITLE
fix: build warnings in analyzer test project

### DIFF
--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/AnalyzerTestHelper.cs
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/AnalyzerTestHelper.cs
@@ -28,13 +28,13 @@ internal static class AnalyzerTestHelper
         );
 
         var optionsProvider = new TestAnalyzerConfigOptionsProvider(
-            new TestAnalyzerConfigOptions(globalOptions ?? new Dictionary<string, string?>())
+            new TestAnalyzerConfigOptions(globalOptions ?? new Dictionary<string, string?>(StringComparer.Ordinal))
         );
         var analyzerOptions = new AnalyzerOptions([], optionsProvider);
 
         var withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
 
-        var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync();
+        var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
 
         return diagnostics;
     }

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/IsPackableProjectDiagnosticAnalyzerTests.cs
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/IsPackableProjectDiagnosticAnalyzerTests.cs
@@ -11,7 +11,7 @@ using TUnit.Assertions.Enums;
 public class IsPackableProjectDiagnosticAnalyzerTests
 {
     private static Dictionary<string, string?> CreateValidOptions() =>
-        new()
+        new(StringComparer.Ordinal)
         {
             ["build_property.ispackable"] = "true",
             ["build_property.packageid"] = "Some.Package.Id",
@@ -28,12 +28,11 @@ public class IsPackableProjectDiagnosticAnalyzerTests
     [Test]
     public async Task Analyze_IsPackableNotSet_NoDiagnostics()
     {
-        var options = new Dictionary<string, string?>();
+        var options = new Dictionary<string, string?>(StringComparer.Ordinal);
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -41,12 +40,14 @@ public class IsPackableProjectDiagnosticAnalyzerTests
     [Test]
     public async Task Analyze_IsPackableFalse_NoDiagnostics()
     {
-        var options = new Dictionary<string, string?> { ["build_property.ispackable"] = "false" };
+        var options = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["build_property.ispackable"] = "false",
+        };
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -54,12 +55,14 @@ public class IsPackableProjectDiagnosticAnalyzerTests
     [Test]
     public async Task Analyze_IsPackableUnparseable_TreatedAsNotPackable_NoDiagnostics()
     {
-        var options = new Dictionary<string, string?> { ["build_property.ispackable"] = "notabool" };
+        var options = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["build_property.ispackable"] = "notabool",
+        };
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -69,10 +72,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
     {
         var options = CreateValidOptions();
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -91,10 +93,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         _ = options.Remove(key);
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo(expectedId);
@@ -114,10 +115,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         options[key] = "   ";
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo(expectedId);
@@ -129,10 +129,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         _ = options.Remove("build_property.copyrightyearstart");
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("NED0009");
@@ -144,10 +143,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         options["build_property.copyrightyearstart"] = "abc";
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("NED0009");
@@ -159,10 +157,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         options["build_property.copyrightyearstart"] = "1900";
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -173,10 +170,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         options["build_property.copyrightyearstart"] = "9999";
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -187,10 +183,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         options["build_property.copyrightyearstart"] = "1899";
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("NED0009");
@@ -202,10 +197,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         options["build_property.copyrightyearstart"] = "10000";
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("NED0009");
@@ -217,10 +211,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         options["build_property.copyrightyearstart"] = "  2024  ";
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -231,10 +224,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         var options = CreateValidOptions();
         _ = options.Remove("build_property.copyrightyearstart");
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Severity).IsEqualTo(DiagnosticSeverity.Info);
@@ -247,10 +239,9 @@ public class IsPackableProjectDiagnosticAnalyzerTests
         _ = options.Remove("build_property.packageid");
         _ = options.Remove("build_property.title");
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new IsPackableProjectDiagnosticAnalyzer(),
-            options
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new IsPackableProjectDiagnosticAnalyzer(), options)
+            .ConfigureAwait(false);
 
         var ids = diagnostics.Select(d => d.Id).OrderBy(id => id, StringComparer.Ordinal).ToArray();
 

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/OldProjectSupportDiagnosticAnalyzerTests.cs
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/OldProjectSupportDiagnosticAnalyzerTests.cs
@@ -10,12 +10,11 @@ public class OldProjectSupportDiagnosticAnalyzerTests
     [Test]
     public async Task Analyze_NeitherKeySet_NoDiagnostics()
     {
-        var globalOptions = new Dictionary<string, string?>();
+        var globalOptions = new Dictionary<string, string?>(StringComparer.Ordinal);
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new OldProjectSupportDiagnosticAnalyzer(),
-            globalOptions
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new OldProjectSupportDiagnosticAnalyzer(), globalOptions)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -23,40 +22,46 @@ public class OldProjectSupportDiagnosticAnalyzerTests
     [Test]
     public async Task Analyze_OnlyDirEngineeringSet_ReportsSingleDiagnostic()
     {
-        var globalOptions = new Dictionary<string, string?> { ["build_property.direngineering"] = "true" };
+        var globalOptions = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["build_property.direngineering"] = "true",
+        };
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new OldProjectSupportDiagnosticAnalyzer(),
-            globalOptions
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new OldProjectSupportDiagnosticAnalyzer(), globalOptions)
+            .ConfigureAwait(false);
 
-        await Assert.That(diagnostics).HasCount().EqualTo(1);
+        await Assert.That(diagnostics).Count().IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("OLD0001");
     }
 
     [Test]
     public async Task Analyze_OnlyDirEngineeringSettingsSet_ReportsSingleDiagnostic()
     {
-        var globalOptions = new Dictionary<string, string?> { ["build_property.direngineeringsettings"] = "true" };
+        var globalOptions = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["build_property.direngineeringsettings"] = "true",
+        };
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new OldProjectSupportDiagnosticAnalyzer(),
-            globalOptions
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new OldProjectSupportDiagnosticAnalyzer(), globalOptions)
+            .ConfigureAwait(false);
 
-        await Assert.That(diagnostics).HasCount().EqualTo(1);
+        await Assert.That(diagnostics).Count().IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("OLD0001");
     }
 
     [Test]
     public async Task Analyze_DirEngineeringWhitespaceOnly_NoDiagnostics()
     {
-        var globalOptions = new Dictionary<string, string?> { ["build_property.direngineering"] = "   " };
+        var globalOptions = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["build_property.direngineering"] = "   ",
+        };
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new OldProjectSupportDiagnosticAnalyzer(),
-            globalOptions
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new OldProjectSupportDiagnosticAnalyzer(), globalOptions)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -64,12 +69,14 @@ public class OldProjectSupportDiagnosticAnalyzerTests
     [Test]
     public async Task Analyze_DirEngineeringSettingsWhitespaceOnly_NoDiagnostics()
     {
-        var globalOptions = new Dictionary<string, string?> { ["build_property.direngineeringsettings"] = "   " };
+        var globalOptions = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["build_property.direngineeringsettings"] = "   ",
+        };
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new OldProjectSupportDiagnosticAnalyzer(),
-            globalOptions
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new OldProjectSupportDiagnosticAnalyzer(), globalOptions)
+            .ConfigureAwait(false);
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -77,18 +84,17 @@ public class OldProjectSupportDiagnosticAnalyzerTests
     [Test]
     public async Task BothKeysConfigured_ReportsSingleDiagnostic()
     {
-        var globalOptions = new Dictionary<string, string?>
+        var globalOptions = new Dictionary<string, string?>(StringComparer.Ordinal)
         {
             ["build_property.direngineering"] = "true",
             ["build_property.direngineeringsettings"] = "true",
         };
 
-        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(
-            new OldProjectSupportDiagnosticAnalyzer(),
-            globalOptions
-        );
+        var diagnostics = await AnalyzerTestHelper
+            .GetDiagnosticsAsync(new OldProjectSupportDiagnosticAnalyzer(), globalOptions)
+            .ConfigureAwait(false);
 
-        await Assert.That(diagnostics).HasCount().EqualTo(1);
+        await Assert.That(diagnostics).Count().IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("OLD0001");
     }
 
@@ -99,7 +105,7 @@ public class OldProjectSupportDiagnosticAnalyzerTests
 
         var supportedDiagnostics = analyzer.SupportedDiagnostics;
 
-        await Assert.That(supportedDiagnostics).HasCount().EqualTo(1);
+        await Assert.That(supportedDiagnostics).Count().IsEqualTo(1);
         await Assert.That(supportedDiagnostics[0].Id).IsEqualTo("OLD0001");
     }
 


### PR DESCRIPTION
## Summary
- Replace deprecated `HasCount()` assertion with `Count()`
- Add `StringComparer.Ordinal` to `Dictionary<string, string?>` instances (MA0002)
- Add `ConfigureAwait(false)` to awaited calls in test code (MA0004)

## Test plan
- [x] `dotnet build` reports 0 warnings, 0 errors
- [x] `dotnet test tests/NetEvolve.Defaults.Analyzer.Tests.Unit` — 55/55 passed