### PR TITLE
fix: UpdateEditorConfig condition for single-targeting projects

### DIFF
--- a/src/NetEvolve.Defaults/buildMultiTargeting/SupportAdditionalFiles.targets
+++ b/src/NetEvolve.Defaults/buildMultiTargeting/SupportAdditionalFiles.targets
@@ -3,7 +3,9 @@
     <IsCrossTargetingProject>false</IsCrossTargetingProject>
     <IsCrossTargetingProject Condition="$(TargetFrameworks) != ''">true</IsCrossTargetingProject>
   </PropertyGroup>
-  <Target Name="UpdateEditorConfig" BeforeTargets="DispatchToInnerBuilds;BeforeBuild;CSharpierFormat" Condition=" '$(IsCrossTargetingProject)' == '$(IsCrossTargetingBuild)' ">
+  <Target Name="UpdateEditorConfig" BeforeTargets="DispatchToInnerBuilds;BeforeBuild;CSharpierFormat"
+          Condition=" ('$(IsCrossTargetingProject)' == 'true' and '$(IsCrossTargetingBuild)' == 'true')
+                    or ('$(IsCrossTargetingProject)' == 'false' and '$(IsCrossTargetingBuild)' != 'true') ">
     <PropertyGroup>
       <ConfigDir>$(SolutionDir)</ConfigDir>
       <ConfigDir Condition=" ('$(ConfigDir)' == '' or '$(ConfigDir)' == '*Undefined*') and '$(MSBuildProjectDirectory)' != ''"

--- a/src/NetEvolve.Defaults/buildMultiTargeting/SupportAdditionalFiles.targets
+++ b/src/NetEvolve.Defaults/buildMultiTargeting/SupportAdditionalFiles.targets
@@ -3,9 +3,12 @@
     <IsCrossTargetingProject>false</IsCrossTargetingProject>
     <IsCrossTargetingProject Condition="$(TargetFrameworks) != ''">true</IsCrossTargetingProject>
   </PropertyGroup>
-  <Target Name="UpdateEditorConfig" BeforeTargets="DispatchToInnerBuilds;BeforeBuild;CSharpierFormat"
-          Condition=" ('$(IsCrossTargetingProject)' == 'true' and '$(IsCrossTargetingBuild)' == 'true')
-                    or ('$(IsCrossTargetingProject)' == 'false' and '$(IsCrossTargetingBuild)' != 'true') ">
+  <Target
+    Name="UpdateEditorConfig"
+    BeforeTargets="DispatchToInnerBuilds;BeforeBuild;CSharpierFormat"
+    Condition=" ('$(IsCrossTargetingProject)' == 'true' and '$(IsCrossTargetingBuild)' == 'true')
+                    or ('$(IsCrossTargetingProject)' == 'false' and '$(IsCrossTargetingBuild)' != 'true') "
+  >
     <PropertyGroup>
       <ConfigDir>$(SolutionDir)</ConfigDir>
       <ConfigDir Condition=" ('$(ConfigDir)' == '' or '$(ConfigDir)' == '*Undefined*') and '$(MSBuildProjectDirectory)' != ''"

--- a/tests/NetEvolve.Defaults.Tests.Unit/MSBuildProjectFixture.cs
+++ b/tests/NetEvolve.Defaults.Tests.Unit/MSBuildProjectFixture.cs
@@ -191,6 +191,7 @@ internal static class MSBuildProjectFixture
 
     internal sealed class EvaluatedProject : IDisposable
     {
+        private static readonly Lock BuildLock = new();
         private readonly ProjectCollection _projectCollection;
         private readonly DirectoryInfo _tempDirectory;
         private bool _disposed;
@@ -204,10 +205,22 @@ internal static class MSBuildProjectFixture
 
         public Project Project { get; }
 
+        public string Directory => _tempDirectory.FullName;
+
         public string GetProperty(string name) => Project.GetPropertyValue(name);
 
         public IReadOnlyList<string> GetItemIncludes(string itemType) =>
             [.. Project.GetItems(itemType).Select(item => item.EvaluatedInclude)];
+
+        public bool BuildTarget(string targetName)
+        {
+            // ProjectInstance.Build uses the process-wide BuildManager, which allows only one build at a
+            // time; TUnit runs tests in parallel by default, so concurrent calls must be serialized.
+            lock (BuildLock)
+            {
+                return Project.CreateProjectInstance().Build(targetName, null);
+            }
+        }
 
         public void Dispose()
         {

--- a/tests/NetEvolve.Defaults.Tests.Unit/SupportAdditionalFilesTests.cs
+++ b/tests/NetEvolve.Defaults.Tests.Unit/SupportAdditionalFilesTests.cs
@@ -1,6 +1,7 @@
-namespace NetEvolve.Defaults.Tests.Unit;
+﻿namespace NetEvolve.Defaults.Tests.Unit;
 
 using System.Collections.Generic;
+using System.IO;
 
 internal class SupportAdditionalFilesTests
 {
@@ -15,7 +16,7 @@ internal class SupportAdditionalFilesTests
 
         using var evaluated = MSBuildProjectFixture.Evaluate("Foo", [TargetsFile], globalProperties);
 
-        await Assert.That(evaluated.GetProperty("IsCrossTargetingProject")).IsEqualTo("true");
+        _ = await Assert.That(evaluated.GetProperty("IsCrossTargetingProject")).IsEqualTo("true");
     }
 
     [Test]
@@ -23,6 +24,44 @@ internal class SupportAdditionalFilesTests
     {
         using var evaluated = MSBuildProjectFixture.Evaluate("Foo", [TargetsFile]);
 
-        await Assert.That(evaluated.GetProperty("IsCrossTargetingProject")).IsEqualTo("false");
+        _ = await Assert.That(evaluated.GetProperty("IsCrossTargetingProject")).IsEqualTo("false");
+    }
+
+    [Test]
+    public async Task TargetFrameworksNotSet_UpdateEditorConfig_CopiesEditorConfig()
+    {
+        using var evaluated = MSBuildProjectFixture.Evaluate("Foo", [TargetsFile]);
+        await File.WriteAllTextAsync(Path.Combine(evaluated.Directory, "Directory.Packages.props"), "<Project />")
+            .ConfigureAwait(false);
+
+        var success = evaluated.BuildTarget("UpdateEditorConfig");
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(success).IsTrue();
+            _ = await Assert.That(File.Exists(Path.Combine(evaluated.Directory, ".editorconfig"))).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task TargetFrameworksSet_CrossTargetingInnerBuild_UpdateEditorConfig_DoesNotRun()
+    {
+        var globalProperties = new Dictionary<string, string>
+        {
+            ["TargetFrameworks"] = "net8.0;net9.0",
+            ["IsCrossTargetingBuild"] = "false",
+        };
+
+        using var evaluated = MSBuildProjectFixture.Evaluate("Foo", [TargetsFile], globalProperties);
+        await File.WriteAllTextAsync(Path.Combine(evaluated.Directory, "Directory.Packages.props"), "<Project />")
+            .ConfigureAwait(false);
+
+        var success = evaluated.BuildTarget("UpdateEditorConfig");
+
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(success).IsTrue();
+            _ = await Assert.That(File.Exists(Path.Combine(evaluated.Directory, ".editorconfig"))).IsFalse();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `UpdateEditorConfig`'s condition compared `IsCrossTargetingProject` to `IsCrossTargetingBuild`; the latter is undefined on normal single-targeting builds, so the target never ran for the common case (single `TargetFramework` projects). Condition rewritten to explicitly handle both single- and cross-targeting builds.

## Test plan
- [x] Added tests exercising real target execution: single-targeting projects get `.editorconfig` copied, and a cross-targeting inner build does not re-run the copy.
- [x] Full test suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor configuration generation for cross-targeting and standard builds.
  * Prevented editor configuration files from being generated when cross-targeting conditions are not met.

* **Tests**
  * Added coverage verifying editor configuration creation and suppression under applicable build conditions.
  * Improved test reliability by preventing concurrent MSBuild operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->