### PR TITLE
feat: add NetEvolve.Analyzer as recommended global package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
+    <GlobalPackageReference Include="NetEvolve.Analyzer" Version="0.9.0" />
     <GlobalPackageReference Include="Roslynator.Analyzers" Version="4.15.0" />
     <GlobalPackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
     <GlobalPackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
-    <GlobalPackageReference Include="NetEvolve.Analyzer" Version="0.9.0" />
+    <GlobalPackageReference Include="NetEvolve.Analyzer" Version="0.14.1" />
     <GlobalPackageReference Include="Roslynator.Analyzers" Version="4.15.0" />
     <GlobalPackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
     <GlobalPackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
-    <GlobalPackageReference Include="NetEvolve.Analyzer" Version="0.14.1" />
+    <GlobalPackageReference Include="NetEvolve.Analyzer" Version="0.14.2" />
     <GlobalPackageReference Include="Roslynator.Analyzers" Version="4.15.0" />
     <GlobalPackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
     <GlobalPackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />

--- a/src/NetEvolve.Defaults/buildMultiTargeting/SupportMissingAnalyzers.targets
+++ b/src/NetEvolve.Defaults/buildMultiTargeting/SupportMissingAnalyzers.targets
@@ -4,6 +4,7 @@
     <RecommendedPackage Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" />
     <RecommendedPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" />
     <RecommendedPackage Include="Microsoft.VisualStudio.Threading.Analyzers" />
+    <RecommendedPackage Include="NetEvolve.Analyzer" />
     <RecommendedPackage Include="NetEvolve.Defaults" />
     <RecommendedPackage Include="Roslynator.Analyzers" />
     <RecommendedPackage Include="Roslynator.Formatting.Analyzers" />

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/AnalyzerTestHelper.cs
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/AnalyzerTestHelper.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -16,10 +17,13 @@ internal static class AnalyzerTestHelper
     internal static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
         DiagnosticAnalyzer analyzer,
         IReadOnlyDictionary<string, string?>? globalOptions = null,
-        string source = DefaultSource
+        string source = DefaultSource,
+        CancellationToken cancellationToken = default
     )
     {
-        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, cancellationToken: cancellationToken);
         var compilation = CSharpCompilation.Create(
             "AnalyzerTestAssembly",
             [syntaxTree],
@@ -32,11 +36,11 @@ internal static class AnalyzerTestHelper
         );
         var analyzerOptions = new AnalyzerOptions([], optionsProvider);
 
+#pragma warning disable S8949 // The overload accepting a 'CancellationToken' should be used
         var withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
+#pragma warning restore S8949 // The overload accepting a 'CancellationToken' should be used
 
-        var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
-
-        return diagnostics;
+        return await withAnalyzers.GetAnalyzerDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private sealed class TestAnalyzerConfigOptionsProvider(AnalyzerConfigOptions globalOptions)

--- a/tests/NetEvolve.Defaults.Tests.Unit/SupportMissingAnalyzersTests.cs
+++ b/tests/NetEvolve.Defaults.Tests.Unit/SupportMissingAnalyzersTests.cs
@@ -13,17 +13,18 @@ internal class SupportMissingAnalyzersTests
 
         var recommended = evaluated.GetItemIncludes("RecommendedPackage");
 
-        await Assert.That(recommended).Contains("Meziantou.Analyzer");
-        await Assert.That(recommended).Contains("Microsoft.CodeAnalysis.BannedApiAnalyzers");
-        await Assert.That(recommended).Contains("Microsoft.CodeAnalysis.NetAnalyzers");
-        await Assert.That(recommended).Contains("Microsoft.VisualStudio.Threading.Analyzers");
-        await Assert.That(recommended).Contains("NetEvolve.Defaults");
-        await Assert.That(recommended).Contains("Roslynator.Analyzers");
-        await Assert.That(recommended).Contains("Roslynator.Formatting.Analyzers");
-        await Assert.That(recommended).Contains("Roslynator.CodeAnalysis.Analyzers");
-        await Assert.That(recommended).Contains("Roslynator.CodeFixes");
-        await Assert.That(recommended).Contains("Roslynator.Refactorings");
-        await Assert.That(recommended).Contains("SonarAnalyzer.CSharp");
-        await Assert.That(recommended.Count).IsEqualTo(11);
+        _ = await Assert.That(recommended).Contains("Meziantou.Analyzer");
+        _ = await Assert.That(recommended).Contains("Microsoft.CodeAnalysis.BannedApiAnalyzers");
+        _ = await Assert.That(recommended).Contains("Microsoft.CodeAnalysis.NetAnalyzers");
+        _ = await Assert.That(recommended).Contains("Microsoft.VisualStudio.Threading.Analyzers");
+        _ = await Assert.That(recommended).Contains("NetEvolve.Analyzer");
+        _ = await Assert.That(recommended).Contains("NetEvolve.Defaults");
+        _ = await Assert.That(recommended).Contains("Roslynator.Analyzers");
+        _ = await Assert.That(recommended).Contains("Roslynator.Formatting.Analyzers");
+        _ = await Assert.That(recommended).Contains("Roslynator.CodeAnalysis.Analyzers");
+        _ = await Assert.That(recommended).Contains("Roslynator.CodeFixes");
+        _ = await Assert.That(recommended).Contains("Roslynator.Refactorings");
+        _ = await Assert.That(recommended).Contains("SonarAnalyzer.CSharp");
+        _ = await Assert.That(recommended.Count).IsEqualTo(12);
     }
 }


### PR DESCRIPTION
## Summary
- Add `NetEvolve.Analyzer` as a global package reference
- Add `NetEvolve.Analyzer` to the recommended analyzer packages surfaced for projects without analyzers configured

## Test plan
- [ ] Verify restore succeeds with the new global package reference
- [ ] Verify the recommended-package warning lists `NetEvolve.Analyzer` for a project missing analyzers