### PR TITLE
feat(analyzer): build the analyzer against four Roslyn API versions

### DIFF
--- a/Defaults.slnx
+++ b/Defaults.slnx
@@ -18,6 +18,10 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.csproj" />
+    <Project Path="src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_4.csproj" />
+    <Project Path="src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_7.csproj" />
+    <Project Path="src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_14.csproj" />
+    <Project Path="src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn5_6.csproj" />
     <Project Path="src/NetEvolve.Defaults/NetEvolve.Defaults.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/src/NetEvolve.Defaults.Analyzer/Diagnostics/IsPackableProjectDiagnosticAnalyzer.cs
+++ b/src/NetEvolve.Defaults.Analyzer/Diagnostics/IsPackableProjectDiagnosticAnalyzer.cs
@@ -51,7 +51,7 @@ internal sealed class IsPackableProjectDiagnosticAnalyzer : DiagnosticAnalyzer
     );
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        [
+        ImmutableArray.Create(
             _ruleNED0001,
             _ruleNED0002,
             _ruleNED0003,
@@ -60,8 +60,8 @@ internal sealed class IsPackableProjectDiagnosticAnalyzer : DiagnosticAnalyzer
             _ruleNED0006,
             _ruleNED0007,
             _ruleNED0008,
-            _ruleNED0009,
-        ];
+            _ruleNED0009
+        );
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEvolve.Defaults.Analyzer/Diagnostics/OldProjectSupportDiagnosticAnalyzer.cs
+++ b/src/NetEvolve.Defaults.Analyzer/Diagnostics/OldProjectSupportDiagnosticAnalyzer.cs
@@ -15,7 +15,7 @@ internal sealed class OldProjectSupportDiagnosticAnalyzer : DiagnosticAnalyzer
         customTags: WellKnownDiagnosticTags.CompilationEnd
     );
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [_ruleOLD0001];
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_ruleOLD0001);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Build.props
+++ b/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Build.props
@@ -1,0 +1,57 @@
+<Project>
+  <!--
+    Shared settings for every Roslyn-version-specific project in this folder
+    (NetEvolve.Defaults.Analyzer.csproj plus the NetEvolve.Defaults.Analyzer.Roslyn*.csproj siblings).
+    Each of them sets RoslynApiVersion and imports this file; they all compile the
+    same *.cs files (default SDK globbing) into a separate obj/bin subfolder keyed
+    by the project name, so they don't collide with one another.
+  -->
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>NetEvolve.Defaults.Analyzer</AssemblyName>
+    <RootNamespace>NetEvolve.Defaults.Analyzer</RootNamespace>
+    <LangVersion Condition=" '$(LangVersion)' != 'preview' ">latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsPackable Condition=" '$(IsPackable)' == '' ">false</IsPackable>
+    <NeutralLanguage>en</NeutralLanguage>
+    <Description>
+      NetEvolve.Defaults.Analyzer provides several diagnostic analyzers, to improve the nuget package quality and consistency.
+    </Description>
+    <NoWarn>$(NoWarn);RS1036</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup Label="Test access to internals">
+    <InternalsVisibleTo Include="NetEvolve.Defaults.Analyzer.Tests.Architecture" />
+    <InternalsVisibleTo Include="NetEvolve.Defaults.Analyzer.Tests.Unit" />
+    <InternalsVisibleTo Include="NetEvolve.Defaults.Analyzer.Tests.Integration" />
+  </ItemGroup>
+
+  <ItemGroup Label="Exclude sibling variants' obj/bin folders">
+    <Compile Remove="obj\**;bin\**" />
+  </ItemGroup>
+
+  <ItemGroup Label="Roslyn">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(RoslynApiVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Label="Generated resources">
+    <Compile Update="Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
+    <EmbeddedResource Update="Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzer release tracking (RS2008)">
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+</Project>

--- a/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_14.csproj
+++ b/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_14.csproj
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <RoslynApiVersion>4.14.0</RoslynApiVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin\$(MSBuildProjectName)\</BaseOutputPath>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="NetEvolve.Defaults.Analyzer.Build.props" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_4.csproj
+++ b/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_4.csproj
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <!-- Oldest supported Roslyn API version. Also the fallback/baseline variant. -->
+    <RoslynApiVersion>4.4.0</RoslynApiVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin\$(MSBuildProjectName)\</BaseOutputPath>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="NetEvolve.Defaults.Analyzer.Build.props" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_7.csproj
+++ b/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn4_7.csproj
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <RoslynApiVersion>4.7.0</RoslynApiVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin\$(MSBuildProjectName)\</BaseOutputPath>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="NetEvolve.Defaults.Analyzer.Build.props" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn5_6.csproj
+++ b/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.Roslyn5_6.csproj
@@ -1,0 +1,14 @@
+<Project>
+  <PropertyGroup>
+    <!-- Latest available Microsoft.CodeAnalysis.CSharp release; matches the centrally pinned
+         package version and is what the test project compiles against. -->
+    <RoslynApiVersion>5.6.0</RoslynApiVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin\$(MSBuildProjectName)\</BaseOutputPath>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="NetEvolve.Defaults.Analyzer.Build.props" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.csproj
+++ b/src/NetEvolve.Defaults.Analyzer/NetEvolve.Defaults.Analyzer.csproj
@@ -8,7 +8,7 @@
     </Description>
     <NeutralLanguage>en</NeutralLanguage>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -18,34 +18,39 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
     <DisableRecommendedPackage>NetEvolve.Defaults</DisableRecommendedPackage>
   </PropertyGroup>
+  <ItemGroup Label="This project only packs the outputs of the Roslyn-version-specific sibling projects">
+    <Compile Remove="**\*.cs" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="build\**" Pack="true" PackagePath="build\" />
     <None Include="buildMultiTargeting\**" Pack="true" PackagePath="buildMultiTargeting\" />
     <None Include="buildTransitive\**" Pack="true" PackagePath="buildTransitive\" />
     <None Include="_._" Pack="true" PackagePath="lib\$(TargetFramework)" Visible="false" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Update="Strings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Strings.resx</DependentUpon>
-    </Compile>
-    <EmbeddedResource Update="Strings.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
-    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  <ItemGroup Label="Roslyn-version builds packed into this package">
+    <ProjectReference Include="NetEvolve.Defaults.Analyzer.Roslyn4_4.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="NetEvolve.Defaults.Analyzer.Roslyn4_7.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="NetEvolve.Defaults.Analyzer.Roslyn4_14.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="NetEvolve.Defaults.Analyzer.Roslyn5_6.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
   <Target Name="_AddAnalyzersToOutput">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).dll" PackagePath="analyzers/dotnet/cs" />
+      <TfmSpecificPackageFile
+        Include="bin\NetEvolve.Defaults.Analyzer.Roslyn4_4\$(Configuration)\netstandard2.0\$(AssemblyName).dll"
+        PackagePath="analyzers/dotnet/roslyn4.4/cs/%(Filename)%(Extension)"
+      />
+      <TfmSpecificPackageFile
+        Include="bin\NetEvolve.Defaults.Analyzer.Roslyn4_7\$(Configuration)\netstandard2.0\$(AssemblyName).dll"
+        PackagePath="analyzers/dotnet/roslyn4.7/cs/%(Filename)%(Extension)"
+      />
+      <TfmSpecificPackageFile
+        Include="bin\NetEvolve.Defaults.Analyzer.Roslyn4_14\$(Configuration)\netstandard2.0\$(AssemblyName).dll"
+        PackagePath="analyzers/dotnet/roslyn4.14/cs/%(Filename)%(Extension)"
+      />
+      <TfmSpecificPackageFile
+        Include="bin\NetEvolve.Defaults.Analyzer.Roslyn5_6\$(Configuration)\netstandard2.0\$(AssemblyName).dll"
+        PackagePath="analyzers/dotnet/roslyn5.6/cs/%(Filename)%(Extension)"
+      />
     </ItemGroup>
   </Target>
   <Import Project=".\..\NetEvolve.Defaults\build\NetEvolve.Defaults.targets" />

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/NetEvolve.Defaults.Analyzer.Tests.Unit.csproj
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/NetEvolve.Defaults.Analyzer.Tests.Unit.csproj
@@ -1,12 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetEvolve_TestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);VSTHRD200;</NoWarn>
   </PropertyGroup>
+  <PropertyGroup Label="Roslyn variant tested per target framework">
+    <_RoslynVariant>4_4</_RoslynVariant>
+    <_RoslynApiVersion>4.4.*</_RoslynApiVersion>
+    <_RoslynVariant Condition=" '$(TargetFramework)' == 'net8.0' ">4_7</_RoslynVariant>
+    <_RoslynApiVersion Condition=" '$(TargetFramework)' == 'net8.0' ">4.7.*</_RoslynApiVersion>
+    <_RoslynVariant Condition=" '$(TargetFramework)' == 'net9.0' ">4_14</_RoslynVariant>
+    <_RoslynApiVersion Condition=" '$(TargetFramework)' == 'net9.0' ">4.14.*</_RoslynApiVersion>
+    <_RoslynVariant Condition=" '$(TargetFramework)' == 'net10.0' ">5_6</_RoslynVariant>
+    <_RoslynApiVersion Condition=" '$(TargetFramework)' == 'net10.0' ">5.6.*</_RoslynApiVersion>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(_RoslynApiVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
     <PackageReference Include="TUnit" />
@@ -15,6 +25,6 @@
     <AssemblyAttribute Include="NetEvolve.Extensions.TUnit.UnitTestAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\NetEvolve.Defaults.Analyzer\NetEvolve.Defaults.Analyzer.Roslyn5_6.csproj" />
+    <ProjectReference Include="..\..\src\NetEvolve.Defaults.Analyzer\NetEvolve.Defaults.Analyzer.Roslyn$(_RoslynVariant).csproj" />
   </ItemGroup>
 </Project>

--- a/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/NetEvolve.Defaults.Analyzer.Tests.Unit.csproj
+++ b/tests/NetEvolve.Defaults.Analyzer.Tests.Unit/NetEvolve.Defaults.Analyzer.Tests.Unit.csproj
@@ -15,6 +15,6 @@
     <AssemblyAttribute Include="NetEvolve.Extensions.TUnit.UnitTestAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\NetEvolve.Defaults.Analyzer\NetEvolve.Defaults.Analyzer.csproj" />
+    <ProjectReference Include="..\..\src\NetEvolve.Defaults.Analyzer\NetEvolve.Defaults.Analyzer.Roslyn5_6.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Similar to dailydevops/analyzer#30.

Splits `NetEvolve.Defaults.Analyzer.csproj` into a packaging-only shell and four Roslyn-version-specific sibling projects, each targeting a different `Microsoft.CodeAnalysis.CSharp` version:

- `NetEvolve.Defaults.Analyzer.Roslyn4_4.csproj` — 4.4.0 (oldest supported; build-verified only)
- `NetEvolve.Defaults.Analyzer.Roslyn4_7.csproj` — 4.7.0
- `NetEvolve.Defaults.Analyzer.Roslyn4_14.csproj` — 4.14.0
- `NetEvolve.Defaults.Analyzer.Roslyn5_6.csproj` — 5.6.0 (latest, matches the centrally pinned version)

All four share their compile settings (target framework, language settings, InternalsVisibleTo, analyzer release tracking, resource codegen) via a new `NetEvolve.Defaults.Analyzer.Build.props`, and each pulls in its own `Microsoft.CodeAnalysis.CSharp` version via CPM's `VersionOverride`.

Each variant's output is packed into a version-qualified `analyzers/dotnet/roslynX.Y/cs` folder in the NuGet package, matching the versioned-analyzer layout the .NET SDK understands from 8.0.400 onward — consumers on older SDKs won't receive an analyzer from this package, same trade-off as the reference PR.

Two collection-expression usages targeting `ImmutableArray<T>` were rewritten as `ImmutableArray.Create(...)`, since older `Microsoft.CodeAnalysis.CSharp` releases pull in a `System.Collections.Immutable` without `[CollectionBuilder]` support.

The unit test project now multi-targets net8.0/net9.0/net10.0, each mapped to a different Roslyn variant (4.7.0 / 4.14.0 / 5.6.0), so the analyzer is actually exercised against three of the four Roslyn versions instead of just compiling against the latest. The 4.4.0 variant remains build-verified only.

Verified: `dotnet build` on the packaging project produces all four DLLs in their versioned `analyzers/dotnet/roslynX.Y/cs` paths, the full solution builds cleanly, and all 165 analyzer unit tests (55 × 3 target frameworks) pass.